### PR TITLE
Fixed the spaces left showing negative numbers

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -13,4 +13,8 @@ class Workshop < ApplicationRecord
   validates :level, inclusion: { in: LEVEL }
   validates :capacity, :price, :duration, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   accepts_nested_attributes_for :photos
+
+  def spaces_left
+    capacity - bookings.count
+  end
 end

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -14,9 +14,7 @@
     </div>
 
     <div class="booking-footer">
-     <% spaces = @workshop.capacity %>
-     <% @workshop.bookings.each { |booking| spaces -= booking.num_guests } %>
-      <p class="my-2 grey s_font"><%= spaces %> space left</p>
+      <p class="my-2 grey s_font"><%= @workshop.spaces_left %> spaces left</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixed the spaces left showing negative random numbers on the show page for a workshop, now it should show proper left spaces